### PR TITLE
feat(execution): add exchange connector trait and mock implementation (#10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ stochastic control theory. It determines optimal bid and ask prices given:
 - [`market_state`]: Market data representation
 - [`risk`]: Position limits, exposure control, and circuit breakers
 - [`analytics`]: Market data analysis and order flow metrics
+- [`execution`]: Exchange connectivity and order management
 - [`types`]: Common types and error definitions
 - [`prelude`]: Convenient re-exports of commonly used types
 

--- a/src/execution/connector.rs
+++ b/src/execution/connector.rs
@@ -1,0 +1,1071 @@
+//! Exchange connector trait and core types.
+//!
+//! This module defines the abstract interface for exchange connectivity,
+//! including order submission, cancellation, and market data retrieval.
+//!
+//! # Design
+//!
+//! The `ExchangeConnector` trait provides a unified interface for:
+//! - Order lifecycle management (submit, cancel, modify)
+//! - Order status queries
+//! - Market data retrieval (order book snapshots)
+//! - Account balance queries
+//!
+//! The `MarketDataStream` trait handles real-time data subscriptions.
+//!
+//! # Example
+//!
+//! ```rust
+//! use market_maker_rs::execution::{
+//!     OrderRequest, Side, OrderType, TimeInForce
+//! };
+//! use market_maker_rs::dec;
+//!
+//! let request = OrderRequest::new(
+//!     "BTC-USD",
+//!     Side::Buy,
+//!     OrderType::Limit,
+//!     Some(dec!(50000.0)),
+//!     dec!(0.1),
+//! );
+//!
+//! assert_eq!(request.symbol, "BTC-USD");
+//! assert_eq!(request.side, Side::Buy);
+//! ```
+
+use async_trait::async_trait;
+use std::fmt;
+
+use crate::Decimal;
+use crate::types::error::MMResult;
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+/// Unique identifier for an order.
+///
+/// Wraps a string identifier that uniquely identifies an order on the exchange.
+///
+/// # Example
+///
+/// ```rust
+/// use market_maker_rs::execution::OrderId;
+///
+/// let order_id = OrderId::new("12345");
+/// assert_eq!(order_id.as_str(), "12345");
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct OrderId(String);
+
+impl OrderId {
+    /// Creates a new order ID.
+    #[must_use]
+    pub fn new(id: impl Into<String>) -> Self {
+        Self(id.into())
+    }
+
+    /// Returns the order ID as a string slice.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Consumes the OrderId and returns the inner String.
+    #[must_use]
+    pub fn into_inner(self) -> String {
+        self.0
+    }
+}
+
+impl fmt::Display for OrderId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl From<String> for OrderId {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
+impl From<&str> for OrderId {
+    fn from(s: &str) -> Self {
+        Self(s.to_string())
+    }
+}
+
+/// Order side (buy or sell).
+///
+/// # Example
+///
+/// ```rust
+/// use market_maker_rs::execution::Side;
+///
+/// let side = Side::Buy;
+/// assert!(side.is_buy());
+/// assert!(!side.is_sell());
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum Side {
+    /// Buy order (bid).
+    Buy,
+    /// Sell order (ask).
+    Sell,
+}
+
+impl Side {
+    /// Returns true if this is a buy order.
+    #[must_use]
+    pub fn is_buy(&self) -> bool {
+        matches!(self, Side::Buy)
+    }
+
+    /// Returns true if this is a sell order.
+    #[must_use]
+    pub fn is_sell(&self) -> bool {
+        matches!(self, Side::Sell)
+    }
+
+    /// Returns the opposite side.
+    #[must_use]
+    pub fn opposite(&self) -> Self {
+        match self {
+            Side::Buy => Side::Sell,
+            Side::Sell => Side::Buy,
+        }
+    }
+}
+
+impl fmt::Display for Side {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Side::Buy => write!(f, "Buy"),
+            Side::Sell => write!(f, "Sell"),
+        }
+    }
+}
+
+/// Order type.
+///
+/// # Example
+///
+/// ```rust
+/// use market_maker_rs::execution::OrderType;
+///
+/// let order_type = OrderType::Limit;
+/// assert!(order_type.requires_price());
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum OrderType {
+    /// Limit order - executes at specified price or better.
+    Limit,
+    /// Market order - executes immediately at best available price.
+    Market,
+    /// Post-only order - only adds liquidity, rejected if would take.
+    PostOnly,
+}
+
+impl OrderType {
+    /// Returns true if this order type requires a price.
+    #[must_use]
+    pub fn requires_price(&self) -> bool {
+        matches!(self, OrderType::Limit | OrderType::PostOnly)
+    }
+
+    /// Returns true if this is a market order.
+    #[must_use]
+    pub fn is_market(&self) -> bool {
+        matches!(self, OrderType::Market)
+    }
+}
+
+impl fmt::Display for OrderType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            OrderType::Limit => write!(f, "Limit"),
+            OrderType::Market => write!(f, "Market"),
+            OrderType::PostOnly => write!(f, "PostOnly"),
+        }
+    }
+}
+
+/// Time in force - how long an order remains active.
+///
+/// # Example
+///
+/// ```rust
+/// use market_maker_rs::execution::TimeInForce;
+///
+/// let tif = TimeInForce::GoodTilCancel;
+/// assert!(!tif.is_immediate());
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Default)]
+pub enum TimeInForce {
+    /// Good til cancel - remains active until filled or cancelled.
+    #[default]
+    GoodTilCancel,
+    /// Immediate or cancel - fills immediately, cancels unfilled portion.
+    ImmediateOrCancel,
+    /// Fill or kill - must fill entirely immediately or cancel.
+    FillOrKill,
+    /// Good til time - remains active until specified timestamp (milliseconds).
+    GoodTilTime(u64),
+}
+
+impl TimeInForce {
+    /// Returns true if this time in force requires immediate execution.
+    #[must_use]
+    pub fn is_immediate(&self) -> bool {
+        matches!(
+            self,
+            TimeInForce::ImmediateOrCancel | TimeInForce::FillOrKill
+        )
+    }
+}
+
+impl fmt::Display for TimeInForce {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            TimeInForce::GoodTilCancel => write!(f, "GTC"),
+            TimeInForce::ImmediateOrCancel => write!(f, "IOC"),
+            TimeInForce::FillOrKill => write!(f, "FOK"),
+            TimeInForce::GoodTilTime(ts) => write!(f, "GTT({})", ts),
+        }
+    }
+}
+
+/// Order status with associated data.
+///
+/// # Example
+///
+/// ```rust
+/// use market_maker_rs::execution::OrderStatus;
+/// use market_maker_rs::dec;
+///
+/// let status = OrderStatus::Open { filled_qty: dec!(0.0) };
+/// assert!(status.is_open());
+/// ```
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum OrderStatus {
+    /// Order is pending submission.
+    Pending,
+    /// Order is open on the book.
+    Open {
+        /// Quantity filled so far.
+        filled_qty: Decimal,
+    },
+    /// Order is partially filled.
+    PartiallyFilled {
+        /// Quantity filled so far.
+        filled_qty: Decimal,
+        /// Remaining quantity.
+        remaining_qty: Decimal,
+    },
+    /// Order is completely filled.
+    Filled {
+        /// Total quantity filled.
+        filled_qty: Decimal,
+        /// Average fill price.
+        avg_price: Decimal,
+    },
+    /// Order was cancelled.
+    Cancelled {
+        /// Quantity filled before cancellation.
+        filled_qty: Decimal,
+    },
+    /// Order was rejected.
+    Rejected {
+        /// Rejection reason.
+        reason: String,
+    },
+}
+
+impl OrderStatus {
+    /// Returns true if the order is still active (pending, open, or partially filled).
+    #[must_use]
+    pub fn is_active(&self) -> bool {
+        matches!(
+            self,
+            OrderStatus::Pending | OrderStatus::Open { .. } | OrderStatus::PartiallyFilled { .. }
+        )
+    }
+
+    /// Returns true if the order is open on the book.
+    #[must_use]
+    pub fn is_open(&self) -> bool {
+        matches!(
+            self,
+            OrderStatus::Open { .. } | OrderStatus::PartiallyFilled { .. }
+        )
+    }
+
+    /// Returns true if the order is terminal (filled, cancelled, or rejected).
+    #[must_use]
+    pub fn is_terminal(&self) -> bool {
+        matches!(
+            self,
+            OrderStatus::Filled { .. }
+                | OrderStatus::Cancelled { .. }
+                | OrderStatus::Rejected { .. }
+        )
+    }
+
+    /// Returns the filled quantity, if any.
+    #[must_use]
+    pub fn filled_qty(&self) -> Decimal {
+        match self {
+            OrderStatus::Pending => Decimal::ZERO,
+            OrderStatus::Open { filled_qty } => *filled_qty,
+            OrderStatus::PartiallyFilled { filled_qty, .. } => *filled_qty,
+            OrderStatus::Filled { filled_qty, .. } => *filled_qty,
+            OrderStatus::Cancelled { filled_qty } => *filled_qty,
+            OrderStatus::Rejected { .. } => Decimal::ZERO,
+        }
+    }
+}
+
+impl fmt::Display for OrderStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            OrderStatus::Pending => write!(f, "Pending"),
+            OrderStatus::Open { filled_qty } => write!(f, "Open(filled={})", filled_qty),
+            OrderStatus::PartiallyFilled {
+                filled_qty,
+                remaining_qty,
+            } => write!(
+                f,
+                "PartiallyFilled(filled={}, remaining={})",
+                filled_qty, remaining_qty
+            ),
+            OrderStatus::Filled {
+                filled_qty,
+                avg_price,
+            } => {
+                write!(f, "Filled(qty={}, avg_price={})", filled_qty, avg_price)
+            }
+            OrderStatus::Cancelled { filled_qty } => write!(f, "Cancelled(filled={})", filled_qty),
+            OrderStatus::Rejected { reason } => write!(f, "Rejected({})", reason),
+        }
+    }
+}
+
+/// Order request for submission to an exchange.
+///
+/// # Example
+///
+/// ```rust
+/// use market_maker_rs::execution::{OrderRequest, Side, OrderType, TimeInForce};
+/// use market_maker_rs::dec;
+///
+/// let request = OrderRequest::new(
+///     "BTC-USD",
+///     Side::Buy,
+///     OrderType::Limit,
+///     Some(dec!(50000.0)),
+///     dec!(0.1),
+/// );
+///
+/// assert_eq!(request.symbol, "BTC-USD");
+/// assert_eq!(request.quantity, dec!(0.1));
+/// ```
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct OrderRequest {
+    /// Trading symbol (e.g., "BTC-USD").
+    pub symbol: String,
+    /// Order side (buy or sell).
+    pub side: Side,
+    /// Order type (limit, market, post-only).
+    pub order_type: OrderType,
+    /// Limit price (required for limit and post-only orders).
+    pub price: Option<Decimal>,
+    /// Order quantity in base currency.
+    pub quantity: Decimal,
+    /// Time in force.
+    pub time_in_force: TimeInForce,
+    /// Client-assigned order ID for tracking.
+    pub client_order_id: Option<String>,
+}
+
+impl OrderRequest {
+    /// Creates a new order request.
+    ///
+    /// # Arguments
+    ///
+    /// * `symbol` - Trading symbol
+    /// * `side` - Order side
+    /// * `order_type` - Order type
+    /// * `price` - Limit price (None for market orders)
+    /// * `quantity` - Order quantity
+    #[must_use]
+    pub fn new(
+        symbol: impl Into<String>,
+        side: Side,
+        order_type: OrderType,
+        price: Option<Decimal>,
+        quantity: Decimal,
+    ) -> Self {
+        Self {
+            symbol: symbol.into(),
+            side,
+            order_type,
+            price,
+            quantity,
+            time_in_force: TimeInForce::default(),
+            client_order_id: None,
+        }
+    }
+
+    /// Creates a limit buy order.
+    #[must_use]
+    pub fn limit_buy(symbol: impl Into<String>, price: Decimal, quantity: Decimal) -> Self {
+        Self::new(symbol, Side::Buy, OrderType::Limit, Some(price), quantity)
+    }
+
+    /// Creates a limit sell order.
+    #[must_use]
+    pub fn limit_sell(symbol: impl Into<String>, price: Decimal, quantity: Decimal) -> Self {
+        Self::new(symbol, Side::Sell, OrderType::Limit, Some(price), quantity)
+    }
+
+    /// Creates a market buy order.
+    #[must_use]
+    pub fn market_buy(symbol: impl Into<String>, quantity: Decimal) -> Self {
+        Self::new(symbol, Side::Buy, OrderType::Market, None, quantity)
+    }
+
+    /// Creates a market sell order.
+    #[must_use]
+    pub fn market_sell(symbol: impl Into<String>, quantity: Decimal) -> Self {
+        Self::new(symbol, Side::Sell, OrderType::Market, None, quantity)
+    }
+
+    /// Sets the time in force.
+    #[must_use]
+    pub fn with_time_in_force(mut self, tif: TimeInForce) -> Self {
+        self.time_in_force = tif;
+        self
+    }
+
+    /// Sets the client order ID.
+    #[must_use]
+    pub fn with_client_order_id(mut self, id: impl Into<String>) -> Self {
+        self.client_order_id = Some(id.into());
+        self
+    }
+
+    /// Returns the notional value of the order (price * quantity).
+    /// Returns None for market orders without a price.
+    #[must_use]
+    pub fn notional(&self) -> Option<Decimal> {
+        self.price.map(|p| p * self.quantity)
+    }
+}
+
+/// Order response from an exchange.
+///
+/// # Example
+///
+/// ```rust
+/// use market_maker_rs::execution::{OrderResponse, OrderId, OrderStatus};
+/// use market_maker_rs::dec;
+///
+/// let response = OrderResponse {
+///     order_id: OrderId::new("12345"),
+///     client_order_id: Some("my-order-1".to_string()),
+///     status: OrderStatus::Open { filled_qty: dec!(0.0) },
+///     timestamp: 1234567890,
+/// };
+///
+/// assert!(response.status.is_open());
+/// ```
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct OrderResponse {
+    /// Exchange-assigned order ID.
+    pub order_id: OrderId,
+    /// Client-assigned order ID (if provided).
+    pub client_order_id: Option<String>,
+    /// Current order status.
+    pub status: OrderStatus,
+    /// Timestamp of the response in milliseconds.
+    pub timestamp: u64,
+}
+
+impl OrderResponse {
+    /// Creates a new order response.
+    #[must_use]
+    pub fn new(order_id: OrderId, status: OrderStatus, timestamp: u64) -> Self {
+        Self {
+            order_id,
+            client_order_id: None,
+            status,
+            timestamp,
+        }
+    }
+
+    /// Sets the client order ID.
+    #[must_use]
+    pub fn with_client_order_id(mut self, id: impl Into<String>) -> Self {
+        self.client_order_id = Some(id.into());
+        self
+    }
+}
+
+/// Trade/fill information.
+///
+/// Represents a single execution (fill) of an order.
+///
+/// # Example
+///
+/// ```rust
+/// use market_maker_rs::execution::{Fill, OrderId, Side};
+/// use market_maker_rs::dec;
+///
+/// let fill = Fill {
+///     order_id: OrderId::new("12345"),
+///     trade_id: "trade-1".to_string(),
+///     price: dec!(50000.0),
+///     quantity: dec!(0.1),
+///     side: Side::Buy,
+///     timestamp: 1234567890,
+///     fee: dec!(0.5),
+///     fee_currency: "USD".to_string(),
+/// };
+///
+/// assert_eq!(fill.notional(), dec!(5000.0));
+/// ```
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct Fill {
+    /// Order ID that was filled.
+    pub order_id: OrderId,
+    /// Unique trade/execution ID.
+    pub trade_id: String,
+    /// Fill price.
+    pub price: Decimal,
+    /// Fill quantity.
+    pub quantity: Decimal,
+    /// Fill side.
+    pub side: Side,
+    /// Fill timestamp in milliseconds.
+    pub timestamp: u64,
+    /// Fee amount.
+    pub fee: Decimal,
+    /// Fee currency.
+    pub fee_currency: String,
+}
+
+impl Fill {
+    /// Returns the notional value of the fill (price * quantity).
+    #[must_use]
+    pub fn notional(&self) -> Decimal {
+        self.price * self.quantity
+    }
+
+    /// Returns the net value after fees.
+    /// For buys: notional + fee (cost)
+    /// For sells: notional - fee (proceeds)
+    #[must_use]
+    pub fn net_value(&self) -> Decimal {
+        match self.side {
+            Side::Buy => self.notional() + self.fee,
+            Side::Sell => self.notional() - self.fee,
+        }
+    }
+}
+
+/// Order book price level.
+///
+/// # Example
+///
+/// ```rust
+/// use market_maker_rs::execution::BookLevel;
+/// use market_maker_rs::dec;
+///
+/// let level = BookLevel::new(dec!(50000.0), dec!(1.5));
+/// assert_eq!(level.notional(), dec!(75000.0));
+/// ```
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct BookLevel {
+    /// Price at this level.
+    pub price: Decimal,
+    /// Total quantity at this level.
+    pub quantity: Decimal,
+}
+
+impl BookLevel {
+    /// Creates a new book level.
+    #[must_use]
+    pub fn new(price: Decimal, quantity: Decimal) -> Self {
+        Self { price, quantity }
+    }
+
+    /// Returns the notional value at this level (price * quantity).
+    #[must_use]
+    pub fn notional(&self) -> Decimal {
+        self.price * self.quantity
+    }
+}
+
+/// Order book snapshot.
+///
+/// Contains the current state of the order book for a symbol.
+///
+/// # Example
+///
+/// ```rust
+/// use market_maker_rs::execution::{OrderBookSnapshot, BookLevel};
+/// use market_maker_rs::dec;
+///
+/// let snapshot = OrderBookSnapshot {
+///     symbol: "BTC-USD".to_string(),
+///     bids: vec![
+///         BookLevel::new(dec!(49990.0), dec!(1.0)),
+///         BookLevel::new(dec!(49980.0), dec!(2.0)),
+///     ],
+///     asks: vec![
+///         BookLevel::new(dec!(50010.0), dec!(1.0)),
+///         BookLevel::new(dec!(50020.0), dec!(2.0)),
+///     ],
+///     timestamp: 1234567890,
+/// };
+///
+/// assert_eq!(snapshot.spread(), Some(dec!(20.0)));
+/// ```
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct OrderBookSnapshot {
+    /// Trading symbol.
+    pub symbol: String,
+    /// Bid levels (sorted by price descending).
+    pub bids: Vec<BookLevel>,
+    /// Ask levels (sorted by price ascending).
+    pub asks: Vec<BookLevel>,
+    /// Snapshot timestamp in milliseconds.
+    pub timestamp: u64,
+}
+
+impl OrderBookSnapshot {
+    /// Creates a new empty order book snapshot.
+    #[must_use]
+    pub fn new(symbol: impl Into<String>, timestamp: u64) -> Self {
+        Self {
+            symbol: symbol.into(),
+            bids: Vec::new(),
+            asks: Vec::new(),
+            timestamp,
+        }
+    }
+
+    /// Returns the best bid price.
+    #[must_use]
+    pub fn best_bid(&self) -> Option<Decimal> {
+        self.bids.first().map(|l| l.price)
+    }
+
+    /// Returns the best ask price.
+    #[must_use]
+    pub fn best_ask(&self) -> Option<Decimal> {
+        self.asks.first().map(|l| l.price)
+    }
+
+    /// Returns the mid price.
+    #[must_use]
+    pub fn mid_price(&self) -> Option<Decimal> {
+        match (self.best_bid(), self.best_ask()) {
+            (Some(bid), Some(ask)) => Some((bid + ask) / Decimal::from(2)),
+            _ => None,
+        }
+    }
+
+    /// Returns the spread (best ask - best bid).
+    #[must_use]
+    pub fn spread(&self) -> Option<Decimal> {
+        match (self.best_bid(), self.best_ask()) {
+            (Some(bid), Some(ask)) => Some(ask - bid),
+            _ => None,
+        }
+    }
+
+    /// Returns the spread as a percentage of mid price.
+    #[must_use]
+    pub fn spread_bps(&self) -> Option<Decimal> {
+        match (self.spread(), self.mid_price()) {
+            (Some(spread), Some(mid)) if mid > Decimal::ZERO => {
+                Some(spread / mid * Decimal::from(10000))
+            }
+            _ => None,
+        }
+    }
+
+    /// Returns total bid depth (sum of all bid quantities).
+    #[must_use]
+    pub fn bid_depth(&self) -> Decimal {
+        self.bids.iter().map(|l| l.quantity).sum()
+    }
+
+    /// Returns total ask depth (sum of all ask quantities).
+    #[must_use]
+    pub fn ask_depth(&self) -> Decimal {
+        self.asks.iter().map(|l| l.quantity).sum()
+    }
+
+    /// Returns the imbalance ratio: (bid_depth - ask_depth) / (bid_depth + ask_depth).
+    #[must_use]
+    pub fn imbalance(&self) -> Decimal {
+        let bid_depth = self.bid_depth();
+        let ask_depth = self.ask_depth();
+        let total = bid_depth + ask_depth;
+        if total > Decimal::ZERO {
+            (bid_depth - ask_depth) / total
+        } else {
+            Decimal::ZERO
+        }
+    }
+}
+
+/// Exchange connector trait for order management.
+///
+/// This trait defines the interface for interacting with an exchange,
+/// including order submission, cancellation, and status queries.
+///
+/// # Implementation Notes
+///
+/// - All methods are async and return `MMResult<T>`
+/// - Implementations should be `Send + Sync` for use with async runtimes
+/// - Consider implementing retry logic for transient failures
+#[async_trait]
+pub trait ExchangeConnector: Send + Sync {
+    /// Submits a new order to the exchange.
+    ///
+    /// # Arguments
+    ///
+    /// * `request` - The order request to submit
+    ///
+    /// # Returns
+    ///
+    /// The order response with the assigned order ID and initial status.
+    async fn submit_order(&self, request: OrderRequest) -> MMResult<OrderResponse>;
+
+    /// Cancels an existing order.
+    ///
+    /// # Arguments
+    ///
+    /// * `order_id` - The ID of the order to cancel
+    ///
+    /// # Returns
+    ///
+    /// The order response with the final status.
+    async fn cancel_order(&self, order_id: &OrderId) -> MMResult<OrderResponse>;
+
+    /// Modifies an existing order (cancel and replace).
+    ///
+    /// # Arguments
+    ///
+    /// * `order_id` - The ID of the order to modify
+    /// * `new_price` - New price (None to keep current)
+    /// * `new_quantity` - New quantity (None to keep current)
+    ///
+    /// # Returns
+    ///
+    /// The order response for the new order.
+    async fn modify_order(
+        &self,
+        order_id: &OrderId,
+        new_price: Option<Decimal>,
+        new_quantity: Option<Decimal>,
+    ) -> MMResult<OrderResponse>;
+
+    /// Gets the current status of an order.
+    ///
+    /// # Arguments
+    ///
+    /// * `order_id` - The ID of the order to query
+    ///
+    /// # Returns
+    ///
+    /// The current order response.
+    async fn get_order_status(&self, order_id: &OrderId) -> MMResult<OrderResponse>;
+
+    /// Gets all open orders for a symbol.
+    ///
+    /// # Arguments
+    ///
+    /// * `symbol` - The trading symbol
+    ///
+    /// # Returns
+    ///
+    /// A list of all open orders.
+    async fn get_open_orders(&self, symbol: &str) -> MMResult<Vec<OrderResponse>>;
+
+    /// Cancels all open orders for a symbol.
+    ///
+    /// # Arguments
+    ///
+    /// * `symbol` - The trading symbol
+    ///
+    /// # Returns
+    ///
+    /// A list of cancelled order responses.
+    async fn cancel_all_orders(&self, symbol: &str) -> MMResult<Vec<OrderResponse>>;
+
+    /// Gets the current order book snapshot.
+    ///
+    /// # Arguments
+    ///
+    /// * `symbol` - The trading symbol
+    /// * `depth` - Number of levels to retrieve
+    ///
+    /// # Returns
+    ///
+    /// The order book snapshot.
+    async fn get_orderbook(&self, symbol: &str, depth: usize) -> MMResult<OrderBookSnapshot>;
+
+    /// Gets the account balance for an asset.
+    ///
+    /// # Arguments
+    ///
+    /// * `asset` - The asset symbol (e.g., "BTC", "USD")
+    ///
+    /// # Returns
+    ///
+    /// The available balance.
+    async fn get_balance(&self, asset: &str) -> MMResult<Decimal>;
+}
+
+/// Market data stream trait for real-time data.
+///
+/// This trait defines the interface for subscribing to and receiving
+/// real-time market data updates.
+#[async_trait]
+pub trait MarketDataStream: Send + Sync {
+    /// Subscribes to order book updates for a symbol.
+    ///
+    /// # Arguments
+    ///
+    /// * `symbol` - The trading symbol
+    async fn subscribe_orderbook(&self, symbol: &str) -> MMResult<()>;
+
+    /// Subscribes to trade stream for a symbol.
+    ///
+    /// # Arguments
+    ///
+    /// * `symbol` - The trading symbol
+    async fn subscribe_trades(&self, symbol: &str) -> MMResult<()>;
+
+    /// Gets the next order book update (blocking).
+    ///
+    /// # Returns
+    ///
+    /// The next order book snapshot.
+    async fn next_orderbook_update(&self) -> MMResult<OrderBookSnapshot>;
+
+    /// Gets the next trade (blocking).
+    ///
+    /// # Returns
+    ///
+    /// The next fill/trade.
+    async fn next_trade(&self) -> MMResult<Fill>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dec;
+
+    #[test]
+    fn test_order_id() {
+        let id = OrderId::new("12345");
+        assert_eq!(id.as_str(), "12345");
+        assert_eq!(id.to_string(), "12345");
+
+        let id2: OrderId = "67890".into();
+        assert_eq!(id2.as_str(), "67890");
+    }
+
+    #[test]
+    fn test_side() {
+        assert!(Side::Buy.is_buy());
+        assert!(!Side::Buy.is_sell());
+        assert!(Side::Sell.is_sell());
+        assert!(!Side::Sell.is_buy());
+        assert_eq!(Side::Buy.opposite(), Side::Sell);
+        assert_eq!(Side::Sell.opposite(), Side::Buy);
+    }
+
+    #[test]
+    fn test_order_type() {
+        assert!(OrderType::Limit.requires_price());
+        assert!(OrderType::PostOnly.requires_price());
+        assert!(!OrderType::Market.requires_price());
+        assert!(OrderType::Market.is_market());
+    }
+
+    #[test]
+    fn test_time_in_force() {
+        assert!(!TimeInForce::GoodTilCancel.is_immediate());
+        assert!(TimeInForce::ImmediateOrCancel.is_immediate());
+        assert!(TimeInForce::FillOrKill.is_immediate());
+        assert!(!TimeInForce::GoodTilTime(1000).is_immediate());
+    }
+
+    #[test]
+    fn test_order_status() {
+        let pending = OrderStatus::Pending;
+        assert!(pending.is_active());
+        assert!(!pending.is_open());
+        assert!(!pending.is_terminal());
+        assert_eq!(pending.filled_qty(), Decimal::ZERO);
+
+        let open = OrderStatus::Open {
+            filled_qty: dec!(0.5),
+        };
+        assert!(open.is_active());
+        assert!(open.is_open());
+        assert!(!open.is_terminal());
+        assert_eq!(open.filled_qty(), dec!(0.5));
+
+        let filled = OrderStatus::Filled {
+            filled_qty: dec!(1.0),
+            avg_price: dec!(100.0),
+        };
+        assert!(!filled.is_active());
+        assert!(!filled.is_open());
+        assert!(filled.is_terminal());
+        assert_eq!(filled.filled_qty(), dec!(1.0));
+
+        let rejected = OrderStatus::Rejected {
+            reason: "test".to_string(),
+        };
+        assert!(rejected.is_terminal());
+        assert_eq!(rejected.filled_qty(), Decimal::ZERO);
+    }
+
+    #[test]
+    fn test_order_request() {
+        let request = OrderRequest::new(
+            "BTC-USD",
+            Side::Buy,
+            OrderType::Limit,
+            Some(dec!(50000.0)),
+            dec!(0.1),
+        );
+
+        assert_eq!(request.symbol, "BTC-USD");
+        assert_eq!(request.side, Side::Buy);
+        assert_eq!(request.order_type, OrderType::Limit);
+        assert_eq!(request.price, Some(dec!(50000.0)));
+        assert_eq!(request.quantity, dec!(0.1));
+        assert_eq!(request.notional(), Some(dec!(5000.0)));
+    }
+
+    #[test]
+    fn test_order_request_builders() {
+        let buy = OrderRequest::limit_buy("BTC-USD", dec!(50000.0), dec!(0.1));
+        assert_eq!(buy.side, Side::Buy);
+        assert_eq!(buy.order_type, OrderType::Limit);
+
+        let sell = OrderRequest::limit_sell("BTC-USD", dec!(51000.0), dec!(0.1));
+        assert_eq!(sell.side, Side::Sell);
+
+        let market_buy = OrderRequest::market_buy("BTC-USD", dec!(0.1));
+        assert_eq!(market_buy.order_type, OrderType::Market);
+        assert_eq!(market_buy.price, None);
+        assert_eq!(market_buy.notional(), None);
+    }
+
+    #[test]
+    fn test_fill() {
+        let fill = Fill {
+            order_id: OrderId::new("12345"),
+            trade_id: "trade-1".to_string(),
+            price: dec!(50000.0),
+            quantity: dec!(0.1),
+            side: Side::Buy,
+            timestamp: 1000,
+            fee: dec!(0.5),
+            fee_currency: "USD".to_string(),
+        };
+
+        assert_eq!(fill.notional(), dec!(5000.0));
+        assert_eq!(fill.net_value(), dec!(5000.5)); // Buy: notional + fee
+
+        let sell_fill = Fill {
+            side: Side::Sell,
+            ..fill.clone()
+        };
+        assert_eq!(sell_fill.net_value(), dec!(4999.5)); // Sell: notional - fee
+    }
+
+    #[test]
+    fn test_book_level() {
+        let level = BookLevel::new(dec!(50000.0), dec!(1.5));
+        assert_eq!(level.notional(), dec!(75000.0));
+    }
+
+    #[test]
+    fn test_order_book_snapshot() {
+        let snapshot = OrderBookSnapshot {
+            symbol: "BTC-USD".to_string(),
+            bids: vec![
+                BookLevel::new(dec!(49990.0), dec!(1.0)),
+                BookLevel::new(dec!(49980.0), dec!(2.0)),
+            ],
+            asks: vec![
+                BookLevel::new(dec!(50010.0), dec!(1.0)),
+                BookLevel::new(dec!(50020.0), dec!(2.0)),
+            ],
+            timestamp: 1000,
+        };
+
+        assert_eq!(snapshot.best_bid(), Some(dec!(49990.0)));
+        assert_eq!(snapshot.best_ask(), Some(dec!(50010.0)));
+        assert_eq!(snapshot.mid_price(), Some(dec!(50000.0)));
+        assert_eq!(snapshot.spread(), Some(dec!(20.0)));
+        assert_eq!(snapshot.bid_depth(), dec!(3.0));
+        assert_eq!(snapshot.ask_depth(), dec!(3.0));
+        assert_eq!(snapshot.imbalance(), Decimal::ZERO);
+    }
+
+    #[test]
+    fn test_order_book_imbalance() {
+        let snapshot = OrderBookSnapshot {
+            symbol: "BTC-USD".to_string(),
+            bids: vec![BookLevel::new(dec!(100.0), dec!(3.0))],
+            asks: vec![BookLevel::new(dec!(101.0), dec!(1.0))],
+            timestamp: 1000,
+        };
+
+        // (3 - 1) / (3 + 1) = 0.5
+        assert_eq!(snapshot.imbalance(), dec!(0.5));
+    }
+
+    #[test]
+    fn test_empty_order_book() {
+        let snapshot = OrderBookSnapshot::new("BTC-USD", 1000);
+
+        assert_eq!(snapshot.best_bid(), None);
+        assert_eq!(snapshot.best_ask(), None);
+        assert_eq!(snapshot.mid_price(), None);
+        assert_eq!(snapshot.spread(), None);
+        assert_eq!(snapshot.imbalance(), Decimal::ZERO);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn test_serialization() {
+        let request = OrderRequest::limit_buy("BTC-USD", dec!(50000.0), dec!(0.1));
+        let json = serde_json::to_string(&request).unwrap();
+        let deserialized: OrderRequest = serde_json::from_str(&json).unwrap();
+        assert_eq!(request, deserialized);
+    }
+}

--- a/src/execution/mock.rs
+++ b/src/execution/mock.rs
@@ -1,0 +1,799 @@
+//! Mock exchange connector for testing.
+//!
+//! This module provides a mock implementation of the `ExchangeConnector` trait
+//! for use in unit and integration tests.
+//!
+//! # Features
+//!
+//! - Configurable latency simulation
+//! - Failure injection for testing error handling
+//! - Order tracking and state management
+//! - Simulated order book
+//!
+//! # Example
+//!
+//! ```rust
+//! use market_maker_rs::execution::{
+//!     MockExchangeConnector, MockConfig, OrderRequest
+//! };
+//! use market_maker_rs::dec;
+//!
+//! let config = MockConfig::default();
+//! let connector = MockExchangeConnector::new(config);
+//!
+//! let request = OrderRequest::limit_buy("BTC-USD", dec!(50000.0), dec!(0.1));
+//! // In an async context: connector.submit_order(request).await
+//! ```
+
+use async_trait::async_trait;
+use std::collections::HashMap;
+use std::sync::RwLock;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use crate::Decimal;
+use crate::types::error::{MMError, MMResult};
+
+use super::connector::{
+    BookLevel, ExchangeConnector, Fill, MarketDataStream, OrderBookSnapshot, OrderId, OrderRequest,
+    OrderResponse, OrderStatus, Side,
+};
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+/// Configuration for the mock exchange connector.
+///
+/// # Example
+///
+/// ```rust
+/// use market_maker_rs::execution::MockConfig;
+///
+/// let config = MockConfig::default()
+///     .with_latency_ms(10)
+///     .with_failure_rate(0.01);
+/// ```
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct MockConfig {
+    /// Simulated latency in milliseconds.
+    pub latency_ms: u64,
+
+    /// Probability of random failure (0.0 to 1.0).
+    pub failure_rate: f64,
+
+    /// Initial balances by asset.
+    pub initial_balances: HashMap<String, Decimal>,
+
+    /// Default order book depth.
+    pub default_depth: usize,
+
+    /// Base price for simulated order book.
+    pub base_price: Decimal,
+
+    /// Spread for simulated order book (as decimal, e.g., 0.001 = 0.1%).
+    pub spread: Decimal,
+}
+
+impl Default for MockConfig {
+    fn default() -> Self {
+        let mut balances = HashMap::new();
+        balances.insert("USD".to_string(), Decimal::from(100_000));
+        balances.insert("BTC".to_string(), Decimal::from(10));
+
+        Self {
+            latency_ms: 0,
+            failure_rate: 0.0,
+            initial_balances: balances,
+            default_depth: 10,
+            base_price: Decimal::from(50_000),
+            spread: Decimal::from_str_exact("0.001").unwrap(),
+        }
+    }
+}
+
+impl MockConfig {
+    /// Creates a new mock config with default values.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the simulated latency.
+    #[must_use]
+    pub fn with_latency_ms(mut self, latency_ms: u64) -> Self {
+        self.latency_ms = latency_ms;
+        self
+    }
+
+    /// Sets the failure rate.
+    #[must_use]
+    pub fn with_failure_rate(mut self, rate: f64) -> Self {
+        self.failure_rate = rate.clamp(0.0, 1.0);
+        self
+    }
+
+    /// Sets the base price for the simulated order book.
+    #[must_use]
+    pub fn with_base_price(mut self, price: Decimal) -> Self {
+        self.base_price = price;
+        self
+    }
+
+    /// Sets the spread for the simulated order book.
+    #[must_use]
+    pub fn with_spread(mut self, spread: Decimal) -> Self {
+        self.spread = spread;
+        self
+    }
+
+    /// Sets an initial balance for an asset.
+    #[must_use]
+    pub fn with_balance(mut self, asset: impl Into<String>, balance: Decimal) -> Self {
+        self.initial_balances.insert(asset.into(), balance);
+        self
+    }
+}
+
+/// Internal order state for tracking.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+struct OrderState {
+    request: OrderRequest,
+    status: OrderStatus,
+    order_id: OrderId,
+    timestamp: u64,
+}
+
+/// Mock exchange connector for testing.
+///
+/// Provides a simulated exchange environment for testing strategies
+/// without connecting to a real exchange.
+///
+/// # Thread Safety
+///
+/// This implementation is thread-safe and can be shared across async tasks.
+///
+/// # Example
+///
+/// ```rust
+/// use market_maker_rs::execution::{
+///     MockExchangeConnector, MockConfig, OrderRequest
+/// };
+/// use market_maker_rs::dec;
+///
+/// let connector = MockExchangeConnector::new(MockConfig::default());
+///
+/// // Create an order request
+/// let request = OrderRequest::limit_buy("BTC-USD", dec!(50000.0), dec!(0.1));
+///
+/// // In an async context, you would call:
+/// // let response = connector.submit_order(request).await.unwrap();
+/// ```
+#[derive(Debug)]
+pub struct MockExchangeConnector {
+    config: MockConfig,
+    orders: RwLock<HashMap<String, OrderState>>,
+    balances: RwLock<HashMap<String, Decimal>>,
+    order_counter: AtomicU64,
+    current_time: AtomicU64,
+}
+
+impl MockExchangeConnector {
+    /// Creates a new mock exchange connector.
+    ///
+    /// # Arguments
+    ///
+    /// * `config` - Configuration for the mock connector
+    #[must_use]
+    pub fn new(config: MockConfig) -> Self {
+        let balances = RwLock::new(config.initial_balances.clone());
+        Self {
+            config,
+            orders: RwLock::new(HashMap::new()),
+            balances,
+            order_counter: AtomicU64::new(1),
+            current_time: AtomicU64::new(1_000_000),
+        }
+    }
+
+    /// Creates a mock connector with default configuration.
+    #[must_use]
+    pub fn with_defaults() -> Self {
+        Self::new(MockConfig::default())
+    }
+
+    /// Returns the current configuration.
+    #[must_use]
+    pub fn config(&self) -> &MockConfig {
+        &self.config
+    }
+
+    /// Sets the current simulated time.
+    pub fn set_time(&self, time: u64) {
+        self.current_time.store(time, Ordering::SeqCst);
+    }
+
+    /// Advances the simulated time.
+    pub fn advance_time(&self, delta: u64) {
+        self.current_time.fetch_add(delta, Ordering::SeqCst);
+    }
+
+    /// Gets the current simulated time.
+    #[must_use]
+    pub fn current_time(&self) -> u64 {
+        self.current_time.load(Ordering::SeqCst)
+    }
+
+    /// Sets the balance for an asset.
+    pub fn set_balance(&self, asset: &str, balance: Decimal) {
+        let mut balances = self.balances.write().unwrap();
+        balances.insert(asset.to_string(), balance);
+    }
+
+    /// Generates a new unique order ID.
+    fn next_order_id(&self) -> OrderId {
+        let id = self.order_counter.fetch_add(1, Ordering::SeqCst);
+        OrderId::new(format!("mock-{}", id))
+    }
+
+    /// Simulates latency if configured.
+    /// Note: Latency simulation is a no-op in the library.
+    /// For actual latency simulation, use tokio::time::sleep in your test code.
+    async fn simulate_latency(&self) {
+        // Latency simulation is intentionally a no-op in the library.
+        // Tests can add their own delays if needed.
+        let _ = self.config.latency_ms;
+    }
+
+    /// Checks if a random failure should occur.
+    fn should_fail(&self) -> bool {
+        if self.config.failure_rate > 0.0 {
+            // Simple deterministic "random" based on order counter
+            let counter = self.order_counter.load(Ordering::SeqCst);
+            let threshold = (self.config.failure_rate * 100.0) as u64;
+            counter % 100 < threshold
+        } else {
+            false
+        }
+    }
+
+    /// Generates a simulated order book.
+    fn generate_orderbook(&self, symbol: &str, depth: usize) -> OrderBookSnapshot {
+        let base_price = self.config.base_price;
+        let half_spread = base_price * self.config.spread / Decimal::from(2);
+
+        let mut bids = Vec::with_capacity(depth);
+        let mut asks = Vec::with_capacity(depth);
+
+        let tick_size = base_price * Decimal::from_str_exact("0.0001").unwrap();
+
+        for i in 0..depth {
+            let offset = tick_size * Decimal::from(i);
+
+            // Bid prices descending from mid - half_spread
+            let bid_price = base_price - half_spread - offset;
+            let bid_qty =
+                Decimal::from(1) + Decimal::from(i) * Decimal::from_str_exact("0.5").unwrap();
+            bids.push(BookLevel::new(bid_price, bid_qty));
+
+            // Ask prices ascending from mid + half_spread
+            let ask_price = base_price + half_spread + offset;
+            let ask_qty =
+                Decimal::from(1) + Decimal::from(i) * Decimal::from_str_exact("0.5").unwrap();
+            asks.push(BookLevel::new(ask_price, ask_qty));
+        }
+
+        OrderBookSnapshot {
+            symbol: symbol.to_string(),
+            bids,
+            asks,
+            timestamp: self.current_time(),
+        }
+    }
+
+    /// Simulates a fill for a market order.
+    fn simulate_market_fill(&self, request: &OrderRequest) -> (OrderStatus, Decimal) {
+        let orderbook = self.generate_orderbook(&request.symbol, 1);
+
+        let fill_price = match request.side {
+            Side::Buy => orderbook.best_ask().unwrap_or(self.config.base_price),
+            Side::Sell => orderbook.best_bid().unwrap_or(self.config.base_price),
+        };
+
+        let status = OrderStatus::Filled {
+            filled_qty: request.quantity,
+            avg_price: fill_price,
+        };
+
+        (status, fill_price)
+    }
+
+    /// Gets the number of open orders.
+    #[must_use]
+    pub fn open_order_count(&self) -> usize {
+        let orders = self.orders.read().unwrap();
+        orders.values().filter(|o| o.status.is_open()).count()
+    }
+
+    /// Gets all order IDs.
+    #[must_use]
+    pub fn all_order_ids(&self) -> Vec<OrderId> {
+        let orders = self.orders.read().unwrap();
+        orders.values().map(|o| o.order_id.clone()).collect()
+    }
+}
+
+#[async_trait]
+impl ExchangeConnector for MockExchangeConnector {
+    async fn submit_order(&self, request: OrderRequest) -> MMResult<OrderResponse> {
+        self.simulate_latency().await;
+
+        if self.should_fail() {
+            return Err(MMError::InvalidMarketState(
+                "simulated exchange failure".to_string(),
+            ));
+        }
+
+        let order_id = self.next_order_id();
+        let timestamp = self.current_time();
+
+        let status = if request.order_type.is_market() {
+            let (status, _) = self.simulate_market_fill(&request);
+            status
+        } else {
+            OrderStatus::Open {
+                filled_qty: Decimal::ZERO,
+            }
+        };
+
+        let state = OrderState {
+            request: request.clone(),
+            status: status.clone(),
+            order_id: order_id.clone(),
+            timestamp,
+        };
+
+        {
+            let mut orders = self.orders.write().unwrap();
+            orders.insert(order_id.as_str().to_string(), state);
+        }
+
+        Ok(OrderResponse {
+            order_id,
+            client_order_id: request.client_order_id,
+            status,
+            timestamp,
+        })
+    }
+
+    async fn cancel_order(&self, order_id: &OrderId) -> MMResult<OrderResponse> {
+        self.simulate_latency().await;
+
+        if self.should_fail() {
+            return Err(MMError::InvalidMarketState(
+                "simulated exchange failure".to_string(),
+            ));
+        }
+
+        let mut orders = self.orders.write().unwrap();
+        let state = orders
+            .get_mut(order_id.as_str())
+            .ok_or_else(|| MMError::InvalidMarketState(format!("order not found: {}", order_id)))?;
+
+        if state.status.is_terminal() {
+            return Err(MMError::InvalidMarketState(format!(
+                "order already terminal: {}",
+                order_id
+            )));
+        }
+
+        let filled_qty = state.status.filled_qty();
+        state.status = OrderStatus::Cancelled { filled_qty };
+
+        Ok(OrderResponse {
+            order_id: order_id.clone(),
+            client_order_id: state.request.client_order_id.clone(),
+            status: state.status.clone(),
+            timestamp: self.current_time(),
+        })
+    }
+
+    async fn modify_order(
+        &self,
+        order_id: &OrderId,
+        new_price: Option<Decimal>,
+        new_quantity: Option<Decimal>,
+    ) -> MMResult<OrderResponse> {
+        self.simulate_latency().await;
+
+        // Cancel the existing order
+        let cancelled = self.cancel_order(order_id).await?;
+
+        // Get the original request
+        let original_request = {
+            let orders = self.orders.read().unwrap();
+            let state = orders.get(order_id.as_str()).ok_or_else(|| {
+                MMError::InvalidMarketState(format!("order not found: {}", order_id))
+            })?;
+            state.request.clone()
+        };
+
+        // Create a new order with modified parameters
+        let new_request = OrderRequest {
+            price: new_price.or(original_request.price),
+            quantity: new_quantity.unwrap_or(original_request.quantity),
+            ..original_request
+        };
+
+        // Submit the new order
+        let mut response = self.submit_order(new_request).await?;
+
+        // Preserve the client order ID
+        response.client_order_id = cancelled.client_order_id;
+
+        Ok(response)
+    }
+
+    async fn get_order_status(&self, order_id: &OrderId) -> MMResult<OrderResponse> {
+        self.simulate_latency().await;
+
+        let orders = self.orders.read().unwrap();
+        let state = orders
+            .get(order_id.as_str())
+            .ok_or_else(|| MMError::InvalidMarketState(format!("order not found: {}", order_id)))?;
+
+        Ok(OrderResponse {
+            order_id: order_id.clone(),
+            client_order_id: state.request.client_order_id.clone(),
+            status: state.status.clone(),
+            timestamp: self.current_time(),
+        })
+    }
+
+    async fn get_open_orders(&self, symbol: &str) -> MMResult<Vec<OrderResponse>> {
+        self.simulate_latency().await;
+
+        let orders = self.orders.read().unwrap();
+        let open_orders: Vec<OrderResponse> = orders
+            .values()
+            .filter(|state| state.request.symbol == symbol && state.status.is_open())
+            .map(|state| OrderResponse {
+                order_id: state.order_id.clone(),
+                client_order_id: state.request.client_order_id.clone(),
+                status: state.status.clone(),
+                timestamp: self.current_time(),
+            })
+            .collect();
+
+        Ok(open_orders)
+    }
+
+    async fn cancel_all_orders(&self, symbol: &str) -> MMResult<Vec<OrderResponse>> {
+        self.simulate_latency().await;
+
+        let order_ids: Vec<OrderId> = {
+            let orders = self.orders.read().unwrap();
+            orders
+                .values()
+                .filter(|state| state.request.symbol == symbol && state.status.is_open())
+                .map(|state| state.order_id.clone())
+                .collect()
+        };
+
+        let mut responses = Vec::new();
+        for order_id in order_ids {
+            if let Ok(response) = self.cancel_order(&order_id).await {
+                responses.push(response);
+            }
+        }
+
+        Ok(responses)
+    }
+
+    async fn get_orderbook(&self, symbol: &str, depth: usize) -> MMResult<OrderBookSnapshot> {
+        self.simulate_latency().await;
+
+        if self.should_fail() {
+            return Err(MMError::InvalidMarketState(
+                "simulated exchange failure".to_string(),
+            ));
+        }
+
+        Ok(self.generate_orderbook(symbol, depth))
+    }
+
+    async fn get_balance(&self, asset: &str) -> MMResult<Decimal> {
+        self.simulate_latency().await;
+
+        let balances = self.balances.read().unwrap();
+        Ok(*balances.get(asset).unwrap_or(&Decimal::ZERO))
+    }
+}
+
+#[async_trait]
+impl MarketDataStream for MockExchangeConnector {
+    async fn subscribe_orderbook(&self, _symbol: &str) -> MMResult<()> {
+        // Mock implementation - always succeeds
+        Ok(())
+    }
+
+    async fn subscribe_trades(&self, _symbol: &str) -> MMResult<()> {
+        // Mock implementation - always succeeds
+        Ok(())
+    }
+
+    async fn next_orderbook_update(&self) -> MMResult<OrderBookSnapshot> {
+        // Return a simulated order book
+        Ok(self.generate_orderbook("BTC-USD", self.config.default_depth))
+    }
+
+    async fn next_trade(&self) -> MMResult<Fill> {
+        // Return a simulated trade
+        Ok(Fill {
+            order_id: OrderId::new("mock-trade"),
+            trade_id: format!("trade-{}", self.current_time()),
+            price: self.config.base_price,
+            quantity: Decimal::from_str_exact("0.1").unwrap(),
+            side: Side::Buy,
+            timestamp: self.current_time(),
+            fee: Decimal::from_str_exact("0.001").unwrap(),
+            fee_currency: "USD".to_string(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dec;
+
+    #[tokio::test]
+    async fn test_submit_limit_order() {
+        let connector = MockExchangeConnector::with_defaults();
+
+        let request = OrderRequest::limit_buy("BTC-USD", dec!(50000.0), dec!(0.1));
+        let response = connector.submit_order(request).await.unwrap();
+
+        assert!(response.status.is_open());
+        assert!(!response.order_id.as_str().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_submit_market_order() {
+        let connector = MockExchangeConnector::with_defaults();
+
+        let request = OrderRequest::market_buy("BTC-USD", dec!(0.1));
+        let response = connector.submit_order(request).await.unwrap();
+
+        assert!(response.status.is_terminal());
+        match response.status {
+            OrderStatus::Filled { filled_qty, .. } => {
+                assert_eq!(filled_qty, dec!(0.1));
+            }
+            _ => panic!("expected filled status"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_cancel_order() {
+        let connector = MockExchangeConnector::with_defaults();
+
+        let request = OrderRequest::limit_buy("BTC-USD", dec!(50000.0), dec!(0.1));
+        let response = connector.submit_order(request).await.unwrap();
+
+        let cancelled = connector.cancel_order(&response.order_id).await.unwrap();
+        assert!(cancelled.status.is_terminal());
+        match cancelled.status {
+            OrderStatus::Cancelled { filled_qty } => {
+                assert_eq!(filled_qty, Decimal::ZERO);
+            }
+            _ => panic!("expected cancelled status"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_cancel_nonexistent_order() {
+        let connector = MockExchangeConnector::with_defaults();
+
+        let result = connector.cancel_order(&OrderId::new("nonexistent")).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_get_order_status() {
+        let connector = MockExchangeConnector::with_defaults();
+
+        let request = OrderRequest::limit_buy("BTC-USD", dec!(50000.0), dec!(0.1));
+        let response = connector.submit_order(request).await.unwrap();
+
+        let status = connector
+            .get_order_status(&response.order_id)
+            .await
+            .unwrap();
+        assert!(status.status.is_open());
+    }
+
+    #[tokio::test]
+    async fn test_get_open_orders() {
+        let connector = MockExchangeConnector::with_defaults();
+
+        // Submit multiple orders
+        connector
+            .submit_order(OrderRequest::limit_buy("BTC-USD", dec!(50000.0), dec!(0.1)))
+            .await
+            .unwrap();
+        connector
+            .submit_order(OrderRequest::limit_sell(
+                "BTC-USD",
+                dec!(51000.0),
+                dec!(0.1),
+            ))
+            .await
+            .unwrap();
+        connector
+            .submit_order(OrderRequest::limit_buy("ETH-USD", dec!(3000.0), dec!(1.0)))
+            .await
+            .unwrap();
+
+        let btc_orders = connector.get_open_orders("BTC-USD").await.unwrap();
+        assert_eq!(btc_orders.len(), 2);
+
+        let eth_orders = connector.get_open_orders("ETH-USD").await.unwrap();
+        assert_eq!(eth_orders.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_cancel_all_orders() {
+        let connector = MockExchangeConnector::with_defaults();
+
+        // Submit multiple orders
+        connector
+            .submit_order(OrderRequest::limit_buy("BTC-USD", dec!(50000.0), dec!(0.1)))
+            .await
+            .unwrap();
+        connector
+            .submit_order(OrderRequest::limit_sell(
+                "BTC-USD",
+                dec!(51000.0),
+                dec!(0.1),
+            ))
+            .await
+            .unwrap();
+
+        let cancelled = connector.cancel_all_orders("BTC-USD").await.unwrap();
+        assert_eq!(cancelled.len(), 2);
+
+        let open = connector.get_open_orders("BTC-USD").await.unwrap();
+        assert!(open.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_modify_order() {
+        let connector = MockExchangeConnector::with_defaults();
+
+        let request = OrderRequest::limit_buy("BTC-USD", dec!(50000.0), dec!(0.1));
+        let response = connector.submit_order(request).await.unwrap();
+
+        let modified = connector
+            .modify_order(&response.order_id, Some(dec!(49000.0)), None)
+            .await
+            .unwrap();
+
+        assert!(modified.status.is_open());
+        assert_ne!(modified.order_id, response.order_id); // New order ID
+    }
+
+    #[tokio::test]
+    async fn test_get_orderbook() {
+        let connector = MockExchangeConnector::with_defaults();
+
+        let orderbook = connector.get_orderbook("BTC-USD", 5).await.unwrap();
+
+        assert_eq!(orderbook.symbol, "BTC-USD");
+        assert_eq!(orderbook.bids.len(), 5);
+        assert_eq!(orderbook.asks.len(), 5);
+        assert!(orderbook.best_bid().is_some());
+        assert!(orderbook.best_ask().is_some());
+        assert!(orderbook.spread().unwrap() > Decimal::ZERO);
+    }
+
+    #[tokio::test]
+    async fn test_get_balance() {
+        let connector = MockExchangeConnector::with_defaults();
+
+        let usd_balance = connector.get_balance("USD").await.unwrap();
+        assert_eq!(usd_balance, Decimal::from(100_000));
+
+        let btc_balance = connector.get_balance("BTC").await.unwrap();
+        assert_eq!(btc_balance, Decimal::from(10));
+
+        let unknown = connector.get_balance("UNKNOWN").await.unwrap();
+        assert_eq!(unknown, Decimal::ZERO);
+    }
+
+    #[tokio::test]
+    async fn test_set_balance() {
+        let connector = MockExchangeConnector::with_defaults();
+
+        connector.set_balance("ETH", dec!(100.0));
+        let balance = connector.get_balance("ETH").await.unwrap();
+        assert_eq!(balance, dec!(100.0));
+    }
+
+    #[tokio::test]
+    async fn test_time_management() {
+        let connector = MockExchangeConnector::with_defaults();
+
+        let initial_time = connector.current_time();
+        connector.advance_time(1000);
+        assert_eq!(connector.current_time(), initial_time + 1000);
+
+        connector.set_time(5000);
+        assert_eq!(connector.current_time(), 5000);
+    }
+
+    #[tokio::test]
+    async fn test_client_order_id() {
+        let connector = MockExchangeConnector::with_defaults();
+
+        let request = OrderRequest::limit_buy("BTC-USD", dec!(50000.0), dec!(0.1))
+            .with_client_order_id("my-order-1");
+
+        let response = connector.submit_order(request).await.unwrap();
+        assert_eq!(response.client_order_id, Some("my-order-1".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_market_data_stream() {
+        let connector = MockExchangeConnector::with_defaults();
+
+        // Subscribe (always succeeds in mock)
+        connector.subscribe_orderbook("BTC-USD").await.unwrap();
+        connector.subscribe_trades("BTC-USD").await.unwrap();
+
+        // Get updates
+        let orderbook = connector.next_orderbook_update().await.unwrap();
+        assert!(!orderbook.bids.is_empty());
+
+        let trade = connector.next_trade().await.unwrap();
+        assert!(trade.quantity > Decimal::ZERO);
+    }
+
+    #[test]
+    fn test_mock_config_builder() {
+        let config = MockConfig::new()
+            .with_latency_ms(50)
+            .with_failure_rate(0.1)
+            .with_base_price(dec!(60000.0))
+            .with_spread(dec!(0.002))
+            .with_balance("ETH", dec!(50.0));
+
+        assert_eq!(config.latency_ms, 50);
+        assert_eq!(config.failure_rate, 0.1);
+        assert_eq!(config.base_price, dec!(60000.0));
+        assert_eq!(config.spread, dec!(0.002));
+        assert_eq!(config.initial_balances.get("ETH"), Some(&dec!(50.0)));
+    }
+
+    #[tokio::test]
+    async fn test_open_order_count() {
+        let connector = MockExchangeConnector::with_defaults();
+
+        assert_eq!(connector.open_order_count(), 0);
+
+        connector
+            .submit_order(OrderRequest::limit_buy("BTC-USD", dec!(50000.0), dec!(0.1)))
+            .await
+            .unwrap();
+
+        assert_eq!(connector.open_order_count(), 1);
+
+        connector
+            .submit_order(OrderRequest::market_buy("BTC-USD", dec!(0.1)))
+            .await
+            .unwrap();
+
+        // Market order is filled immediately, so still 1 open
+        assert_eq!(connector.open_order_count(), 1);
+    }
+}

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -1,0 +1,46 @@
+//! Execution module for exchange connectivity and order management.
+//!
+//! This module provides traits and types for exchange interaction, enabling
+//! multiple venue support and facilitating testing through mock implementations.
+//!
+//! # Overview
+//!
+//! The execution module defines:
+//!
+//! - **Order types**: `OrderRequest`, `OrderResponse`, `OrderStatus`
+//! - **Market data types**: `BookLevel`, `OrderBookSnapshot`, `Fill`
+//! - **Connector traits**: `ExchangeConnector`, `MarketDataStream`
+//! - **Mock implementation**: `MockExchangeConnector` for testing
+//!
+//! # Example
+//!
+//! ```rust
+//! use market_maker_rs::execution::{
+//!     OrderRequest, Side, OrderType, TimeInForce, ExchangeConnector
+//! };
+//! use market_maker_rs::dec;
+//!
+//! // Create an order request
+//! let request = OrderRequest::new(
+//!     "BTC-USD",
+//!     Side::Buy,
+//!     OrderType::Limit,
+//!     Some(dec!(50000.0)),
+//!     dec!(0.1),
+//! );
+//!
+//! // In practice, you would use a real exchange connector
+//! // let response = connector.submit_order(request).await?;
+//! ```
+
+/// Exchange connector trait and types.
+pub mod connector;
+
+/// Mock exchange connector for testing.
+pub mod mock;
+
+pub use connector::{
+    BookLevel, ExchangeConnector, Fill, MarketDataStream, OrderBookSnapshot, OrderId, OrderRequest,
+    OrderResponse, OrderStatus, OrderType, Side, TimeInForce,
+};
+pub use mock::{MockConfig, MockExchangeConnector};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@
 //! - [`market_state`]: Market data representation
 //! - [`risk`]: Position limits, exposure control, and circuit breakers
 //! - [`analytics`]: Market data analysis and order flow metrics
+//! - [`execution`]: Exchange connectivity and order management
 //! - [`types`]: Common types and error definitions
 //! - [`prelude`]: Convenient re-exports of commonly used types
 //!
@@ -89,6 +90,14 @@ pub mod types;
 /// - Trade flow metrics and VWAP calculation
 /// - Trade intensity measurement
 pub mod analytics;
+
+/// Execution module for exchange connectivity and order management.
+///
+/// This module provides traits and types for exchange interaction:
+/// - Order submission, cancellation, and modification
+/// - Market data retrieval (order book snapshots)
+/// - Mock implementation for testing
+pub mod execution;
 
 /// Prelude module for convenient imports.
 pub mod prelude;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -52,3 +52,10 @@ pub use crate::analytics::vpin::{
     BucketStats, TradeClassifier, VPINCalculator, VPINConfig, VolumeBucket,
 };
 // Note: Trade is already exported from strategy::adaptive_spread
+
+// Re-export execution types
+pub use crate::execution::{
+    BookLevel, ExchangeConnector, Fill, MarketDataStream, MockConfig, MockExchangeConnector,
+    OrderBookSnapshot, OrderId, OrderRequest, OrderResponse, OrderStatus, OrderType, Side,
+    TimeInForce,
+};


### PR DESCRIPTION
- Add OrderId, Side, OrderType, TimeInForce, OrderStatus types
- Add OrderRequest struct with builder methods (limit_buy, limit_sell, market_buy, market_sell)
- Add OrderResponse struct for exchange responses
- Add Fill struct for trade/execution information
- Add BookLevel and OrderBookSnapshot for market data
- Add ExchangeConnector async trait with methods:
  - submit_order(), cancel_order(), modify_order()
  - get_order_status(), get_open_orders(), cancel_all_orders()
  - get_orderbook(), get_balance()
- Add MarketDataStream trait for real-time data subscriptions
- Add MockExchangeConnector for testing:
  - Configurable latency and failure injection
  - Order tracking and state management
  - Simulated order book generation
  - Balance management
- Add MockConfig with builder pattern
- Full test coverage for all types and mock implementation
- Export types in prelude

Closes #10
