### PR TITLE
docs: fix unresolved doc links in calibration module

### DIFF
--- a/src/strategy/calibration.rs
+++ b/src/strategy/calibration.rs
@@ -13,12 +13,12 @@
 //!
 //! # Components
 //!
-//! - [`CalibrationConfig`]: Configuration for calibration process
-//! - [`CalibrationResult`]: Result with value, confidence interval, and quality
-//! - [`RiskAversionCalibrator`]: Calibrates γ from half-life or history
-//! - [`OrderIntensityCalibrator`]: Calibrates k from fill observations
-//! - [`VolatilityRegimeDetector`]: Detects and classifies volatility regimes
-//! - [`ParameterOptimizer`]: Combines all calibrators for full optimization
+//! - **CalibrationConfig**: Configuration for calibration process
+//! - **CalibrationResult**: Result with value, confidence interval, and quality
+//! - **RiskAversionCalibrator**: Calibrates γ from half-life or history
+//! - **OrderIntensityCalibrator**: Calibrates k from fill observations
+//! - **VolatilityRegimeDetector**: Detects and classifies volatility regimes
+//! - **ParameterOptimizer**: Combines all calibrators for full optimization
 //!
 //! # Example
 //!


### PR DESCRIPTION
Replace intra-doc links with bold text formatting to fix
rustdoc warnings about unresolved links to CalibrationConfig,
CalibrationResult, RiskAversionCalibrator, OrderIntensityCalibrator,
VolatilityRegimeDetector, and ParameterOptimizer.
