### PR TITLE
test: improve test coverage for alerts, engine, and decimal modules

### DIFF
--- a/src/types/decimal.rs
+++ b/src/types/decimal.rs
@@ -253,4 +253,27 @@ mod tests {
         // Should handle error gracefully
         let _ = result;
     }
+
+    #[test]
+    fn test_decimal_ln_negative_value() {
+        // ln of negative value should produce NaN which fails conversion
+        let result = decimal_ln(dec!(-1.0));
+        // Result is NaN from f64, which fails Decimal::from_f64
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_decimal_sqrt_negative_value() {
+        // sqrt of negative value should produce NaN which fails conversion
+        let result = decimal_sqrt(dec!(-1.0));
+        // Result is NaN from f64, which fails Decimal::from_f64
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_decimal_ln_zero() {
+        // ln(0) = -infinity, which fails conversion
+        let result = decimal_ln(dec!(0.0));
+        assert!(result.is_err());
+    }
 }


### PR DESCRIPTION
- Add tests for AlertType::type_key() covering all 11 variants
- Add tests for AlertType::default_message() covering all variants
- Add tests for Alert::Display implementation
- Add tests for LogAlertHandler with all severity levels
- Add tests for CallbackAlertHandler::accepts_severity and name()
- Add tests for CollectingAlertHandler::accepts_severity and name()
- Add test for AlertManager::acknowledge with nonexistent ID
- Add tests for BacktestResult::avg_trade_pnl with zero trades
- Add tests for BacktestConfig builder methods
- Add tests for BacktestEngine with various configurations
- Add tests for decimal_ln with negative and zero values
- Add tests for decimal_sqrt with negative values

Total: 598 unit tests passing
